### PR TITLE
Bugfix in Mxl.Input: Close underlying zip file

### DIFF
--- a/src/main/java/org/audiveris/proxymusic/mxl/Mxl.java
+++ b/src/main/java/org/audiveris/proxymusic/mxl/Mxl.java
@@ -12,6 +12,7 @@
 package org.audiveris.proxymusic.mxl;
 
 import java.io.BufferedOutputStream;
+import java.io.Closeable;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
@@ -91,6 +92,7 @@ public abstract class Mxl
      * Class {@code Input} allows to read a .mxl file.
      */
     public static class Input
+            implements Closeable
     {
         //~ Instance fields ------------------------------------------------------------------------
 
@@ -99,6 +101,9 @@ public abstract class Mxl
 
         /** MXL container. */
         private final Container container;
+
+        /** Flag to indicate if the zip file has already been closed. */
+        private boolean closed;
 
         //~ Constructors ---------------------------------------------------------------------------
         /**
@@ -166,6 +171,23 @@ public abstract class Mxl
         {
             return Collections.unmodifiableList(container.rootFiles);
         }
+
+        /**
+         * Close the underlying zip file.
+         *
+         * @throws IOException propagated from {@link ZipFile#close()}
+         */
+        @Override
+        public void close ()
+                throws IOException
+        {
+            if (closed) {
+                return;
+            }
+            zipFile.close();
+            closed = true;
+        }
+
     }
 
     //--------------//

--- a/src/test/java/org/audiveris/proxymusic/mxl/MxlTest.java
+++ b/src/test/java/org/audiveris/proxymusic/mxl/MxlTest.java
@@ -82,21 +82,21 @@ public class MxlTest
 
         System.out.println("Unmarshalling ...");
 
-        Mxl.Input mif = new Mxl.Input(new File(fileName));
+        try (Mxl.Input mif = new Mxl.Input(new File(fileName))) {
+            for (RootFile rootFile : mif.getRootFiles()) {
+                System.out.println("   " + rootFile);
 
-        for (RootFile rootFile : mif.getRootFiles()) {
-            System.out.println("   " + rootFile);
+                ZipEntry zipEntry = mif.getEntry(rootFile.fullPath);
+                System.out.println("   entryTime: " + new Date(zipEntry.getTime()));
+            }
 
-            ZipEntry zipEntry = mif.getEntry(rootFile.fullPath);
-            System.out.println("   entryTime: " + new Date(zipEntry.getTime()));
+            RootFile first = mif.getRootFiles().get(0);
+            ZipEntry zipEntry = mif.getEntry(first.fullPath);
+            InputStream is = mif.getInputStream(zipEntry);
+            ScorePartwise newScorePartwise = (ScorePartwise) Marshalling.unmarshal(is);
+            System.out.println(new Dumper.Column(newScorePartwise).toString());
+            System.out.println(new Dumper.Column(newScorePartwise.getIdentification()).toString());
         }
-
-        RootFile first = mif.getRootFiles().get(0);
-        ZipEntry zipEntry = mif.getEntry(first.fullPath);
-        InputStream is = mif.getInputStream(zipEntry);
-        ScorePartwise newScorePartwise = (ScorePartwise) Marshalling.unmarshal(is);
-        System.out.println(new Dumper.Column(newScorePartwise).toString());
-        System.out.println(new Dumper.Column(newScorePartwise.getIdentification()).toString());
         System.out.println("Unmarshalled.");
     }
 

--- a/src/test/java/org/audiveris/proxymusic/opus/MxlOpusTest.java
+++ b/src/test/java/org/audiveris/proxymusic/opus/MxlOpusTest.java
@@ -18,6 +18,7 @@ import org.audiveris.proxymusic.util.DummyGenerator;
 import org.audiveris.proxymusic.util.Dumper;
 import org.audiveris.proxymusic.util.Marshalling;
 
+import org.junit.After;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -27,6 +28,7 @@ import junit.framework.TestCase;
 
 import java.io.File;
 import java.io.FileOutputStream;
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.zip.ZipEntry;
@@ -76,6 +78,15 @@ public class MxlOpusTest
         // Test in that order
         storing();
         reloading();
+    }
+
+    @After
+    public void cleanup()
+            throws IOException
+    {
+        if (mi != null) {
+            mi.close();
+        }
     }
 
     //-------------//


### PR DESCRIPTION
Hi @hbitteur,

I noticed the `ZipFile` in `Mxl.Input` implements `Closable` but is never closed. I therefore made `Mxl.Input` also implement `Closeable` and closed the `zipFile` there. I also adapted the tests accordingly.

Cheers,
Peter